### PR TITLE
Terjeio Jog cancel patch integration

### DIFF
--- a/protocol.c
+++ b/protocol.c
@@ -1,0 +1,772 @@
+/*
+  protocol.c - controls Grbl execution protocol and procedures
+  Part of Grbl
+
+  Copyright (c) 2011-2016 Sungeun K. Jeon for Gnea Research LLC
+  Copyright (c) 2009-2011 Simen Svale Skogsrud
+
+  Grbl is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Grbl is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "grbl.h"
+
+// Define line flags. Includes comment type tracking and line overflow detection.
+#define LINE_FLAG_OVERFLOW bit(0)
+#define LINE_FLAG_COMMENT_PARENTHESES bit(1)
+#define LINE_FLAG_COMMENT_SEMICOLON bit(2)
+
+
+static char line[LINE_BUFFER_SIZE]; // Line to be executed. Zero-terminated.
+
+static void protocol_exec_rt_suspend();
+
+
+/*
+  GRBL PRIMARY LOOP:
+*/
+void protocol_main_loop()
+{
+  // Perform some machine checks to make sure everything is good to go.
+  #ifdef CHECK_LIMITS_AT_INIT
+    if (bit_istrue(settings.flags, BITFLAG_HARD_LIMIT_ENABLE)) {
+      if (limits_get_state()) {
+        sys.state = STATE_ALARM; // Ensure alarm state is active.
+        report_feedback_message(MESSAGE_CHECK_LIMITS);
+      }
+    }
+  #endif
+  // Check for and report alarm state after a reset, error, or an initial power up.
+  // NOTE: Sleep mode disables the stepper drivers and position can't be guaranteed.
+  // Re-initialize the sleep state as an ALARM mode to ensure user homes or acknowledges.
+  if (sys.state & (STATE_ALARM | STATE_SLEEP)) {
+    report_feedback_message(MESSAGE_ALARM_LOCK);
+    sys.state = STATE_ALARM; // Ensure alarm state is set.
+  } else {
+    // Check if the safety door is open.
+    sys.state = STATE_IDLE;
+    if (system_check_safety_door_ajar()) {
+      bit_true(sys_rt_exec_state, EXEC_SAFETY_DOOR);
+      protocol_execute_realtime(); // Enter safety door mode. Should return as IDLE state.
+    }
+    // All systems go!
+    system_execute_startup(line); // Execute startup script.
+  }
+
+  // ---------------------------------------------------------------------------------
+  // Primary loop! Upon a system abort, this exits back to main() to reset the system.
+  // This is also where Grbl idles while waiting for something to do.
+  // ---------------------------------------------------------------------------------
+
+  uint8_t line_flags = 0;
+  uint8_t char_counter = 0;
+  uint8_t c;
+  for (;;) {
+
+    // Process one line of incoming serial data, as the data becomes available. Performs an
+    // initial filtering by removing spaces and comments and capitalizing all letters.
+    while((c = serial_read()) != SERIAL_NO_DATA) {
+	  #ifdef SERIAL_CANCEL
+		if(c == SERIAL_CANCEL) {
+			line_flags = char_counter = 0;
+			if (sys.state & STATE_JOG) // Block all other states from invoking motion cancel.
+			system_set_exec_state_flag(EXEC_MOTION_CANCEL);
+		} else
+	  #endif
+      if ((c == '\n') || (c == '\r')) { // End of line reached
+
+        protocol_execute_realtime(); // Runtime command check point.
+        if (sys.abort) { return; } // Bail to calling function upon system abort
+
+        line[char_counter] = 0; // Set string termination character.
+        #ifdef REPORT_ECHO_LINE_RECEIVED
+          report_echo_line_received(line);
+        #endif
+
+        // Direct and execute one line of formatted input, and report status of execution.
+        if (line_flags & LINE_FLAG_OVERFLOW) {
+          // Report line overflow error.
+          report_status_message(STATUS_OVERFLOW);
+        } else if (line[0] == 0) {
+          // Empty or comment line. For syncing purposes.
+          report_status_message(STATUS_OK);
+        } else if (line[0] == '$') {
+          // Grbl '$' system command
+          report_status_message(system_execute_line(line));
+        } else if (sys.state & (STATE_ALARM | STATE_JOG)) {
+          // Everything else is gcode. Block if in alarm or jog mode.
+          report_status_message(STATUS_SYSTEM_GC_LOCK);
+        } else {
+          // Parse and execute g-code block.
+          report_status_message(gc_execute_line(line));
+        }
+
+        // Reset tracking data for next line.
+        line_flags = 0;
+        char_counter = 0;
+
+      } else {
+
+        if (line_flags) {
+          // Throw away all (except EOL) comment characters and overflow characters.
+          if (c == ')') {
+            // End of '()' comment. Resume line allowed.
+            if (line_flags & LINE_FLAG_COMMENT_PARENTHESES) { line_flags &= ~(LINE_FLAG_COMMENT_PARENTHESES); }
+          }
+        } else {
+          if (c <= ' ') {
+            // Throw away whitepace and control characters
+          } else if (c == '/') {
+            // Block delete NOT SUPPORTED. Ignore character.
+            // NOTE: If supported, would simply need to check the system if block delete is enabled.
+          } else if (c == '(') {
+            // Enable comments flag and ignore all characters until ')' or EOL.
+            // NOTE: This doesn't follow the NIST definition exactly, but is good enough for now.
+            // In the future, we could simply remove the items within the comments, but retain the
+            // comment control characters, so that the g-code parser can error-check it.
+            line_flags |= LINE_FLAG_COMMENT_PARENTHESES;
+          } else if (c == ';') {
+            // NOTE: ';' comment to EOL is a LinuxCNC definition. Not NIST.
+            line_flags |= LINE_FLAG_COMMENT_SEMICOLON;
+          // TODO: Install '%' feature
+          // } else if (c == '%') {
+            // Program start-end percent sign NOT SUPPORTED.
+            // NOTE: This maybe installed to tell Grbl when a program is running vs manual input,
+            // where, during a program, the system auto-cycle start will continue to execute
+            // everything until the next '%' sign. This will help fix resuming issues with certain
+            // functions that empty the planner buffer to execute its task on-time.
+          } else if (char_counter >= (LINE_BUFFER_SIZE-1)) {
+            // Detect line buffer overflow and set flag.
+            line_flags |= LINE_FLAG_OVERFLOW;
+          } else if (c >= 'a' && c <= 'z') { // Upcase lowercase
+            line[char_counter++] = c-'a'+'A';
+          } else {
+            line[char_counter++] = c;
+          }
+        }
+
+      }
+    }
+
+    // If there are no more characters in the serial read buffer to be processed and executed,
+    // this indicates that g-code streaming has either filled the planner buffer or has
+    // completed. In either case, auto-cycle start, if enabled, any queued moves.
+    protocol_auto_cycle_start();
+
+    protocol_execute_realtime();  // Runtime command check point.
+    if (sys.abort) { return; } // Bail to main() program loop to reset system.
+  }
+
+  return; /* Never reached */
+}
+
+
+// Block until all buffered steps are executed or in a cycle state. Works with feed hold
+// during a synchronize call, if it should happen. Also, waits for clean cycle end.
+void protocol_buffer_synchronize()
+{
+  // If system is queued, ensure cycle resumes if the auto start flag is present.
+  protocol_auto_cycle_start();
+  do {
+    protocol_execute_realtime();   // Check and execute run-time commands
+    if (sys.abort) { return; } // Check for system abort
+  } while (plan_get_current_block() || (sys.state == STATE_CYCLE));
+}
+
+
+// Auto-cycle start triggers when there is a motion ready to execute and if the main program is not
+// actively parsing commands.
+// NOTE: This function is called from the main loop, buffer sync, and mc_line() only and executes
+// when one of these conditions exist respectively: There are no more blocks sent (i.e. streaming
+// is finished, single commands), a command that needs to wait for the motions in the buffer to
+// execute calls a buffer sync, or the planner buffer is full and ready to go.
+void protocol_auto_cycle_start()
+{
+  if (plan_get_current_block() != NULL) { // Check if there are any blocks in the buffer.
+    system_set_exec_state_flag(EXEC_CYCLE_START); // If so, execute them!
+  }
+}
+
+
+// This function is the general interface to Grbl's real-time command execution system. It is called
+// from various check points in the main program, primarily where there may be a while loop waiting
+// for a buffer to clear space or any point where the execution time from the last check point may
+// be more than a fraction of a second. This is a way to execute realtime commands asynchronously
+// (aka multitasking) with grbl's g-code parsing and planning functions. This function also serves
+// as an interface for the interrupts to set the system realtime flags, where only the main program
+// handles them, removing the need to define more computationally-expensive volatile variables. This
+// also provides a controlled way to execute certain tasks without having two or more instances of
+// the same task, such as the planner recalculating the buffer upon a feedhold or overrides.
+// NOTE: The sys_rt_exec_state variable flags are set by any process, step or serial interrupts, pinouts,
+// limit switches, or the main program.
+void protocol_execute_realtime()
+{
+  protocol_exec_rt_system();
+  if (sys.suspend) { protocol_exec_rt_suspend(); }
+}
+
+
+// Executes run-time commands, when required. This function primarily operates as Grbl's state
+// machine and controls the various real-time features Grbl has to offer.
+// NOTE: Do not alter this unless you know exactly what you are doing!
+void protocol_exec_rt_system()
+{
+  uint8_t rt_exec; // Temp variable to avoid calling volatile multiple times.
+  rt_exec = sys_rt_exec_alarm; // Copy volatile sys_rt_exec_alarm.
+  if (rt_exec) { // Enter only if any bit flag is true
+    // System alarm. Everything has shutdown by something that has gone severely wrong. Report
+    // the source of the error to the user. If critical, Grbl disables by entering an infinite
+    // loop until system reset/abort.
+    sys.state = STATE_ALARM; // Set system alarm state
+    report_alarm_message(rt_exec);
+    // Halt everything upon a critical event flag. Currently hard and soft limits flag this.
+    if ((rt_exec == EXEC_ALARM_HARD_LIMIT) || (rt_exec == EXEC_ALARM_SOFT_LIMIT)) {
+      report_feedback_message(MESSAGE_CRITICAL_EVENT);
+      system_clear_exec_state_flag(EXEC_RESET); // Disable any existing reset
+      do {
+        // Block everything, except reset and status reports, until user issues reset or power
+        // cycles. Hard limits typically occur while unattended or not paying attention. Gives
+        // the user and a GUI time to do what is needed before resetting, like killing the
+        // incoming stream. The same could be said about soft limits. While the position is not
+        // lost, continued streaming could cause a serious crash if by chance it gets executed.
+      } while (bit_isfalse(sys_rt_exec_state,EXEC_RESET));
+    }
+    system_clear_exec_alarm(); // Clear alarm
+  }
+
+  rt_exec = sys_rt_exec_state; // Copy volatile sys_rt_exec_state.
+  if (rt_exec) {
+
+    // Execute system abort.
+    if (rt_exec & EXEC_RESET) {
+      sys.abort = true;  // Only place this is set true.
+      return; // Nothing else to do but exit.
+    }
+
+    // Execute and serial print status
+    if (rt_exec & EXEC_STATUS_REPORT) {
+      report_realtime_status();
+      system_clear_exec_state_flag(EXEC_STATUS_REPORT);
+    }
+
+    // NOTE: Once hold is initiated, the system immediately enters a suspend state to block all
+    // main program processes until either reset or resumed. This ensures a hold completes safely.
+    if (rt_exec & (EXEC_MOTION_CANCEL | EXEC_FEED_HOLD | EXEC_SAFETY_DOOR | EXEC_SLEEP)) {
+
+      // State check for allowable states for hold methods.
+      if (!(sys.state & (STATE_ALARM | STATE_CHECK_MODE))) {
+      
+        // If in CYCLE or JOG states, immediately initiate a motion HOLD.
+        if (sys.state & (STATE_CYCLE | STATE_JOG)) {
+          if (!(sys.suspend & (SUSPEND_MOTION_CANCEL | SUSPEND_JOG_CANCEL))) { // Block, if already holding.
+            st_update_plan_block_parameters(); // Notify stepper module to recompute for hold deceleration.
+            sys.step_control = STEP_CONTROL_EXECUTE_HOLD; // Initiate suspend state with active flag.
+            if (sys.state == STATE_JOG) { // Jog cancelled upon any hold event, except for sleeping.
+              if (!(rt_exec & EXEC_SLEEP)) { sys.suspend |= SUSPEND_JOG_CANCEL; } 
+            }
+          }
+        }
+        // If IDLE, Grbl is not in motion. Simply indicate suspend state and hold is complete.
+        if (sys.state == STATE_IDLE) { sys.suspend = SUSPEND_HOLD_COMPLETE; }
+
+        // Execute and flag a motion cancel with deceleration and return to idle. Used primarily by probing cycle
+        // to halt and cancel the remainder of the motion.
+        if (rt_exec & EXEC_MOTION_CANCEL) {
+          // MOTION_CANCEL only occurs during a CYCLE, but a HOLD and SAFETY_DOOR may been initiated beforehand
+          // to hold the CYCLE. Motion cancel is valid for a single planner block motion only, while jog cancel
+          // will handle and clear multiple planner block motions.
+          if (!(sys.state & STATE_JOG)) { sys.suspend |= SUSPEND_MOTION_CANCEL; } // NOTE: State is STATE_CYCLE.
+        }
+
+        // Execute a feed hold with deceleration, if required. Then, suspend system.
+        if (rt_exec & EXEC_FEED_HOLD) {
+          // Block SAFETY_DOOR, JOG, and SLEEP states from changing to HOLD state.
+          if (!(sys.state & (STATE_SAFETY_DOOR | STATE_JOG | STATE_SLEEP))) { sys.state = STATE_HOLD; }
+        }
+
+        // Execute a safety door stop with a feed hold and disable spindle/coolant.
+        // NOTE: Safety door differs from feed holds by stopping everything no matter state, disables powered
+        // devices (spindle/coolant), and blocks resuming until switch is re-engaged.
+        if (rt_exec & EXEC_SAFETY_DOOR) {
+          report_feedback_message(MESSAGE_SAFETY_DOOR_AJAR);
+          // If jogging, block safety door methods until jog cancel is complete. Just flag that it happened.
+          if (!(sys.suspend & SUSPEND_JOG_CANCEL)) {
+            // Check if the safety re-opened during a restore parking motion only. Ignore if
+            // already retracting, parked or in sleep state.
+            if (sys.state == STATE_SAFETY_DOOR) {
+              if (sys.suspend & SUSPEND_INITIATE_RESTORE) { // Actively restoring
+                #ifdef PARKING_ENABLE
+                  // Set hold and reset appropriate control flags to restart parking sequence.
+                  if (sys.step_control & STEP_CONTROL_EXECUTE_SYS_MOTION) {
+                    st_update_plan_block_parameters(); // Notify stepper module to recompute for hold deceleration.
+                    sys.step_control = (STEP_CONTROL_EXECUTE_HOLD | STEP_CONTROL_EXECUTE_SYS_MOTION);
+                    sys.suspend &= ~(SUSPEND_HOLD_COMPLETE);
+                  } // else NO_MOTION is active.
+                #endif
+                sys.suspend &= ~(SUSPEND_RETRACT_COMPLETE | SUSPEND_INITIATE_RESTORE | SUSPEND_RESTORE_COMPLETE);
+                sys.suspend |= SUSPEND_RESTART_RETRACT;
+              }
+            }
+            if (sys.state != STATE_SLEEP) { sys.state = STATE_SAFETY_DOOR; }
+          }
+          // NOTE: This flag doesn't change when the door closes, unlike sys.state. Ensures any parking motions
+          // are executed if the door switch closes and the state returns to HOLD.
+          sys.suspend |= SUSPEND_SAFETY_DOOR_AJAR;
+        }
+        
+      }
+
+      if (rt_exec & EXEC_SLEEP) {
+        if (sys.state == STATE_ALARM) { sys.suspend |= (SUSPEND_RETRACT_COMPLETE|SUSPEND_HOLD_COMPLETE); }
+        sys.state = STATE_SLEEP; 
+      }
+
+      system_clear_exec_state_flag((EXEC_MOTION_CANCEL | EXEC_FEED_HOLD | EXEC_SAFETY_DOOR | EXEC_SLEEP));
+    }
+
+    // Execute a cycle start by starting the stepper interrupt to begin executing the blocks in queue.
+    if (rt_exec & EXEC_CYCLE_START) {
+      // Block if called at same time as the hold commands: feed hold, motion cancel, and safety door.
+      // Ensures auto-cycle-start doesn't resume a hold without an explicit user-input.
+      if (!(rt_exec & (EXEC_FEED_HOLD | EXEC_MOTION_CANCEL | EXEC_SAFETY_DOOR))) {
+        // Resume door state when parking motion has retracted and door has been closed.
+        if ((sys.state == STATE_SAFETY_DOOR) && !(sys.suspend & SUSPEND_SAFETY_DOOR_AJAR)) {
+          if (sys.suspend & SUSPEND_RESTORE_COMPLETE) {
+            sys.state = STATE_IDLE; // Set to IDLE to immediately resume the cycle.
+          } else if (sys.suspend & SUSPEND_RETRACT_COMPLETE) {
+            // Flag to re-energize powered components and restore original position, if disabled by SAFETY_DOOR.
+            // NOTE: For a safety door to resume, the switch must be closed, as indicated by HOLD state, and
+            // the retraction execution is complete, which implies the initial feed hold is not active. To
+            // restore normal operation, the restore procedures must be initiated by the following flag. Once,
+            // they are complete, it will call CYCLE_START automatically to resume and exit the suspend.
+            sys.suspend |= SUSPEND_INITIATE_RESTORE;
+          }
+        }
+        // Cycle start only when IDLE or when a hold is complete and ready to resume.
+        if ((sys.state == STATE_IDLE) || ((sys.state & STATE_HOLD) && (sys.suspend & SUSPEND_HOLD_COMPLETE))) {
+          if (sys.state == STATE_HOLD && sys.spindle_stop_ovr) {
+            sys.spindle_stop_ovr |= SPINDLE_STOP_OVR_RESTORE_CYCLE; // Set to restore in suspend routine and cycle start after.
+          } else {
+            // Start cycle only if queued motions exist in planner buffer and the motion is not canceled.
+            sys.step_control = STEP_CONTROL_NORMAL_OP; // Restore step control to normal operation
+            if (plan_get_current_block() && bit_isfalse(sys.suspend,SUSPEND_MOTION_CANCEL)) {
+              sys.suspend = SUSPEND_DISABLE; // Break suspend state.
+              sys.state = STATE_CYCLE;
+              st_prep_buffer(); // Initialize step segment buffer before beginning cycle.
+              st_wake_up();
+            } else { // Otherwise, do nothing. Set and resume IDLE state.
+              sys.suspend = SUSPEND_DISABLE; // Break suspend state.
+              sys.state = STATE_IDLE;
+            }
+          }
+        }
+      }
+      system_clear_exec_state_flag(EXEC_CYCLE_START);
+    }
+
+    if (rt_exec & EXEC_CYCLE_STOP) {
+      // Reinitializes the cycle plan and stepper system after a feed hold for a resume. Called by
+      // realtime command execution in the main program, ensuring that the planner re-plans safely.
+      // NOTE: Bresenham algorithm variables are still maintained through both the planner and stepper
+      // cycle reinitializations. The stepper path should continue exactly as if nothing has happened.
+      // NOTE: EXEC_CYCLE_STOP is set by the stepper subsystem when a cycle or feed hold completes.
+      if ((sys.state & (STATE_HOLD|STATE_SAFETY_DOOR|STATE_SLEEP)) && !(sys.soft_limit) && !(sys.suspend & SUSPEND_JOG_CANCEL)) {
+        // Hold complete. Set to indicate ready to resume.  Remain in HOLD or DOOR states until user
+        // has issued a resume command or reset.
+        plan_cycle_reinitialize();
+        if (sys.step_control & STEP_CONTROL_EXECUTE_HOLD) { sys.suspend |= SUSPEND_HOLD_COMPLETE; }
+        bit_false(sys.step_control,(STEP_CONTROL_EXECUTE_HOLD | STEP_CONTROL_EXECUTE_SYS_MOTION));
+      } else {
+        // Motion complete. Includes CYCLE/JOG/HOMING states and jog cancel/motion cancel/soft limit events.
+        // NOTE: Motion and jog cancel both immediately return to idle after the hold completes.
+        if (sys.suspend & SUSPEND_JOG_CANCEL) {   // For jog cancel, flush buffers and sync positions.
+          sys.step_control = STEP_CONTROL_NORMAL_OP;
+          plan_reset();
+          st_reset();
+          gc_sync_position();
+          plan_sync_position();
+        }
+        if (sys.suspend & SUSPEND_SAFETY_DOOR_AJAR) { // Only occurs when safety door opens during jog.
+          sys.suspend &= ~(SUSPEND_JOG_CANCEL);
+          sys.suspend |= SUSPEND_HOLD_COMPLETE;
+          sys.state = STATE_SAFETY_DOOR;
+        } else {
+          sys.suspend = SUSPEND_DISABLE;
+          sys.state = STATE_IDLE;
+        }
+      }
+      system_clear_exec_state_flag(EXEC_CYCLE_STOP);
+    }
+  }
+
+  // Execute overrides.
+  rt_exec = sys_rt_exec_motion_override; // Copy volatile sys_rt_exec_motion_override
+  if (rt_exec) {
+    system_clear_exec_motion_overrides(); // Clear all motion override flags.
+
+    uint8_t new_f_override =  sys.f_override;
+    if (rt_exec & EXEC_FEED_OVR_RESET) { new_f_override = DEFAULT_FEED_OVERRIDE; }
+    if (rt_exec & EXEC_FEED_OVR_COARSE_PLUS) { new_f_override += FEED_OVERRIDE_COARSE_INCREMENT; }
+    if (rt_exec & EXEC_FEED_OVR_COARSE_MINUS) { new_f_override -= FEED_OVERRIDE_COARSE_INCREMENT; }
+    if (rt_exec & EXEC_FEED_OVR_FINE_PLUS) { new_f_override += FEED_OVERRIDE_FINE_INCREMENT; }
+    if (rt_exec & EXEC_FEED_OVR_FINE_MINUS) { new_f_override -= FEED_OVERRIDE_FINE_INCREMENT; }
+    new_f_override = min(new_f_override,MAX_FEED_RATE_OVERRIDE);
+    new_f_override = max(new_f_override,MIN_FEED_RATE_OVERRIDE);
+
+    uint8_t new_r_override = sys.r_override;
+    if (rt_exec & EXEC_RAPID_OVR_RESET) { new_r_override = DEFAULT_RAPID_OVERRIDE; }
+    if (rt_exec & EXEC_RAPID_OVR_MEDIUM) { new_r_override = RAPID_OVERRIDE_MEDIUM; }
+    if (rt_exec & EXEC_RAPID_OVR_LOW) { new_r_override = RAPID_OVERRIDE_LOW; }
+
+    if ((new_f_override != sys.f_override) || (new_r_override != sys.r_override)) {
+      sys.f_override = new_f_override;
+      sys.r_override = new_r_override;
+      sys.report_ovr_counter = 0; // Set to report change immediately
+      plan_update_velocity_profile_parameters();
+      plan_cycle_reinitialize();
+    }
+  }
+
+  rt_exec = sys_rt_exec_accessory_override;
+  if (rt_exec) {
+    system_clear_exec_accessory_overrides(); // Clear all accessory override flags.
+
+    // NOTE: Unlike motion overrides, spindle overrides do not require a planner reinitialization.
+    uint8_t last_s_override =  sys.spindle_speed_ovr;
+    if (rt_exec & EXEC_SPINDLE_OVR_RESET) { last_s_override = DEFAULT_SPINDLE_SPEED_OVERRIDE; }
+    if (rt_exec & EXEC_SPINDLE_OVR_COARSE_PLUS) { last_s_override += SPINDLE_OVERRIDE_COARSE_INCREMENT; }
+    if (rt_exec & EXEC_SPINDLE_OVR_COARSE_MINUS) { last_s_override -= SPINDLE_OVERRIDE_COARSE_INCREMENT; }
+    if (rt_exec & EXEC_SPINDLE_OVR_FINE_PLUS) { last_s_override += SPINDLE_OVERRIDE_FINE_INCREMENT; }
+    if (rt_exec & EXEC_SPINDLE_OVR_FINE_MINUS) { last_s_override -= SPINDLE_OVERRIDE_FINE_INCREMENT; }
+    last_s_override = min(last_s_override,MAX_SPINDLE_SPEED_OVERRIDE);
+    last_s_override = max(last_s_override,MIN_SPINDLE_SPEED_OVERRIDE);
+
+    if (last_s_override != sys.spindle_speed_ovr) {
+      sys.spindle_speed_ovr = last_s_override;
+      // NOTE: Spindle speed overrides during HOLD state are taken care of by suspend function.
+      if (sys.state == STATE_IDLE) { spindle_set_state(gc_state.modal.spindle, gc_state.spindle_speed); }
+			else { bit_true(sys.step_control, STEP_CONTROL_UPDATE_SPINDLE_PWM); }
+      sys.report_ovr_counter = 0; // Set to report change immediately
+    }
+
+    if (rt_exec & EXEC_SPINDLE_OVR_STOP) {
+      // Spindle stop override allowed only while in HOLD state.
+      // NOTE: Report counters are set in spindle_set_state() when spindle stop is executed.
+      if (sys.state == STATE_HOLD) {
+        if (!(sys.spindle_stop_ovr)) { sys.spindle_stop_ovr = SPINDLE_STOP_OVR_INITIATE; }
+        else if (sys.spindle_stop_ovr & SPINDLE_STOP_OVR_ENABLED) { sys.spindle_stop_ovr |= SPINDLE_STOP_OVR_RESTORE; }
+      }
+    }
+
+    // NOTE: Since coolant state always performs a planner sync whenever it changes, the current
+    // run state can be determined by checking the parser state.
+    // NOTE: Coolant overrides only operate during IDLE, CYCLE, HOLD, and JOG states. Ignored otherwise.
+    if (rt_exec & (EXEC_COOLANT_FLOOD_OVR_TOGGLE | EXEC_COOLANT_MIST_OVR_TOGGLE)) {
+      if ((sys.state == STATE_IDLE) || (sys.state & (STATE_CYCLE | STATE_HOLD | STATE_JOG))) {
+        uint8_t coolant_state = gc_state.modal.coolant;
+        #ifdef ENABLE_M7
+          if (rt_exec & EXEC_COOLANT_MIST_OVR_TOGGLE) {
+            if (coolant_state & COOLANT_MIST_ENABLE) { bit_false(coolant_state,COOLANT_MIST_ENABLE); }
+            else { coolant_state |= COOLANT_MIST_ENABLE; }
+          }
+          if (rt_exec & EXEC_COOLANT_FLOOD_OVR_TOGGLE) {
+            if (coolant_state & COOLANT_FLOOD_ENABLE) { bit_false(coolant_state,COOLANT_FLOOD_ENABLE); }
+            else { coolant_state |= COOLANT_FLOOD_ENABLE; }
+          }
+        #else
+          if (coolant_state & COOLANT_FLOOD_ENABLE) { bit_false(coolant_state,COOLANT_FLOOD_ENABLE); }
+          else { coolant_state |= COOLANT_FLOOD_ENABLE; }
+        #endif
+        coolant_set_state(coolant_state); // Report counter set in coolant_set_state().
+        gc_state.modal.coolant = coolant_state;
+      }
+    }
+  }
+
+  #ifdef DEBUG
+    if (sys_rt_exec_debug) {
+      report_realtime_debug();
+      sys_rt_exec_debug = 0;
+    }
+  #endif
+
+  // Reload step segment buffer
+  if (sys.state & (STATE_CYCLE | STATE_HOLD | STATE_SAFETY_DOOR | STATE_HOMING | STATE_SLEEP| STATE_JOG)) {
+    st_prep_buffer();
+  }
+
+}
+
+
+// Handles Grbl system suspend procedures, such as feed hold, safety door, and parking motion.
+// The system will enter this loop, create local variables for suspend tasks, and return to
+// whatever function that invoked the suspend, such that Grbl resumes normal operation.
+// This function is written in a way to promote custom parking motions. Simply use this as a
+// template
+static void protocol_exec_rt_suspend()
+{
+  #ifdef PARKING_ENABLE
+    // Declare and initialize parking local variables
+    float restore_target[N_AXIS];
+    float parking_target[N_AXIS];
+    float retract_waypoint = PARKING_PULLOUT_INCREMENT;
+    plan_line_data_t plan_data;
+    plan_line_data_t *pl_data = &plan_data;
+    memset(pl_data,0,sizeof(plan_line_data_t));
+    pl_data->condition = (PL_COND_FLAG_SYSTEM_MOTION|PL_COND_FLAG_NO_FEED_OVERRIDE);
+    #ifdef USE_LINE_NUMBERS
+      pl_data->line_number = PARKING_MOTION_LINE_NUMBER;
+    #endif
+  #endif
+
+  plan_block_t *block = plan_get_current_block();
+  uint8_t restore_condition;
+  #ifdef VARIABLE_SPINDLE
+    float restore_spindle_speed;
+    if (block == NULL) {
+      restore_condition = (gc_state.modal.spindle | gc_state.modal.coolant);
+      restore_spindle_speed = gc_state.spindle_speed;
+    } else {
+      restore_condition = (block->condition & PL_COND_SPINDLE_MASK) | coolant_get_state();
+      restore_spindle_speed = block->spindle_speed;
+    }
+    #ifdef DISABLE_LASER_DURING_HOLD
+      if (bit_istrue(settings.flags,BITFLAG_LASER_MODE)) { 
+        system_set_exec_accessory_override_flag(EXEC_SPINDLE_OVR_STOP);
+      }
+    #endif
+  #else
+    if (block == NULL) { restore_condition = (gc_state.modal.spindle | gc_state.modal.coolant); }
+    else { restore_condition = (block->condition & PL_COND_SPINDLE_MASK) | coolant_get_state(); }
+  #endif
+
+  while (sys.suspend) {
+
+    if (sys.abort) { return; }
+
+    // Block until initial hold is complete and the machine has stopped motion.
+    if (sys.suspend & SUSPEND_HOLD_COMPLETE) {
+
+      // Parking manager. Handles de/re-energizing, switch state checks, and parking motions for 
+      // the safety door and sleep states.
+      if (sys.state & (STATE_SAFETY_DOOR | STATE_SLEEP)) {
+      
+        // Handles retraction motions and de-energizing.
+        if (bit_isfalse(sys.suspend,SUSPEND_RETRACT_COMPLETE)) {
+
+          // Ensure any prior spindle stop override is disabled at start of safety door routine.
+          sys.spindle_stop_ovr = SPINDLE_STOP_OVR_DISABLED;
+
+          #ifndef PARKING_ENABLE
+
+            spindle_set_state(SPINDLE_DISABLE,0.0); // De-energize
+            coolant_set_state(COOLANT_DISABLE);     // De-energize
+
+          #else
+					
+            // Get current position and store restore location and spindle retract waypoint.
+            system_convert_array_steps_to_mpos(parking_target,sys_position);
+            if (bit_isfalse(sys.suspend,SUSPEND_RESTART_RETRACT)) {
+              memcpy(restore_target,parking_target,sizeof(parking_target));
+              retract_waypoint += restore_target[PARKING_AXIS];
+              retract_waypoint = min(retract_waypoint,PARKING_TARGET);
+            }
+
+            // Execute slow pull-out parking retract motion. Parking requires homing enabled, the
+            // current location not exceeding the parking target location, and laser mode disabled.
+            // NOTE: State is will remain DOOR, until the de-energizing and retract is complete.
+            #ifdef ENABLE_PARKING_OVERRIDE_CONTROL
+            if ((bit_istrue(settings.flags,BITFLAG_HOMING_ENABLE)) &&
+                            (parking_target[PARKING_AXIS] < PARKING_TARGET) &&
+                            bit_isfalse(settings.flags,BITFLAG_LASER_MODE) &&
+                            (sys.override_ctrl == OVERRIDE_PARKING_MOTION)) {
+            #else
+            if ((bit_istrue(settings.flags,BITFLAG_HOMING_ENABLE)) &&
+                            (parking_target[PARKING_AXIS] < PARKING_TARGET) &&
+                            bit_isfalse(settings.flags,BITFLAG_LASER_MODE)) {
+            #endif
+              // Retract spindle by pullout distance. Ensure retraction motion moves away from
+              // the workpiece and waypoint motion doesn't exceed the parking target location.
+              if (parking_target[PARKING_AXIS] < retract_waypoint) {
+                parking_target[PARKING_AXIS] = retract_waypoint;
+                pl_data->feed_rate = PARKING_PULLOUT_RATE;
+                pl_data->condition |= (restore_condition & PL_COND_ACCESSORY_MASK); // Retain accessory state
+                pl_data->spindle_speed = restore_spindle_speed;
+                mc_parking_motion(parking_target, pl_data);
+              }
+
+              // NOTE: Clear accessory state after retract and after an aborted restore motion.
+              pl_data->condition = (PL_COND_FLAG_SYSTEM_MOTION|PL_COND_FLAG_NO_FEED_OVERRIDE);
+              pl_data->spindle_speed = 0.0;
+              spindle_set_state(SPINDLE_DISABLE,0.0); // De-energize
+              coolant_set_state(COOLANT_DISABLE); // De-energize
+
+              // Execute fast parking retract motion to parking target location.
+              if (parking_target[PARKING_AXIS] < PARKING_TARGET) {
+                parking_target[PARKING_AXIS] = PARKING_TARGET;
+                pl_data->feed_rate = PARKING_RATE;
+                mc_parking_motion(parking_target, pl_data);
+              }
+
+            } else {
+
+              // Parking motion not possible. Just disable the spindle and coolant.
+              // NOTE: Laser mode does not start a parking motion to ensure the laser stops immediately.
+              spindle_set_state(SPINDLE_DISABLE,0.0); // De-energize
+              coolant_set_state(COOLANT_DISABLE);     // De-energize
+
+            }
+
+          #endif
+
+          sys.suspend &= ~(SUSPEND_RESTART_RETRACT);
+          sys.suspend |= SUSPEND_RETRACT_COMPLETE;
+
+        } else {
+
+          
+          if (sys.state == STATE_SLEEP) {
+            report_feedback_message(MESSAGE_SLEEP_MODE);
+            // Spindle and coolant should already be stopped, but do it again just to be sure.
+            spindle_set_state(SPINDLE_DISABLE,0.0); // De-energize
+            coolant_set_state(COOLANT_DISABLE); // De-energize
+            st_go_idle(); // Disable steppers
+            while (!(sys.abort)) { protocol_exec_rt_system(); } // Do nothing until reset.
+            return; // Abort received. Return to re-initialize.
+          }    
+          
+          // Allows resuming from parking/safety door. Actively checks if safety door is closed and ready to resume.
+          if (sys.state == STATE_SAFETY_DOOR) {
+            if (!(system_check_safety_door_ajar())) {
+              sys.suspend &= ~(SUSPEND_SAFETY_DOOR_AJAR); // Reset door ajar flag to denote ready to resume.
+            }
+          }
+
+          // Handles parking restore and safety door resume.
+          if (sys.suspend & SUSPEND_INITIATE_RESTORE) {
+
+            #ifdef PARKING_ENABLE
+              // Execute fast restore motion to the pull-out position. Parking requires homing enabled.
+              // NOTE: State is will remain DOOR, until the de-energizing and retract is complete.
+              #ifdef ENABLE_PARKING_OVERRIDE_CONTROL
+              if (((settings.flags & (BITFLAG_HOMING_ENABLE|BITFLAG_LASER_MODE)) == BITFLAG_HOMING_ENABLE) &&
+                   (sys.override_ctrl == OVERRIDE_PARKING_MOTION)) {
+              #else
+              if ((settings.flags & (BITFLAG_HOMING_ENABLE|BITFLAG_LASER_MODE)) == BITFLAG_HOMING_ENABLE) {
+              #endif
+                // Check to ensure the motion doesn't move below pull-out position.
+                if (parking_target[PARKING_AXIS] <= PARKING_TARGET) {
+                  parking_target[PARKING_AXIS] = retract_waypoint;
+                  pl_data->feed_rate = PARKING_RATE;
+                  mc_parking_motion(parking_target, pl_data);
+                }
+              }
+            #endif
+
+            // Delayed Tasks: Restart spindle and coolant, delay to power-up, then resume cycle.
+            if (gc_state.modal.spindle != SPINDLE_DISABLE) {
+              // Block if safety door re-opened during prior restore actions.
+              if (bit_isfalse(sys.suspend,SUSPEND_RESTART_RETRACT)) {
+                if (bit_istrue(settings.flags,BITFLAG_LASER_MODE)) {
+                  // When in laser mode, ignore spindle spin-up delay. Set to turn on laser when cycle starts.
+                  bit_true(sys.step_control, STEP_CONTROL_UPDATE_SPINDLE_PWM);
+                } else {
+                  spindle_set_state((restore_condition & (PL_COND_FLAG_SPINDLE_CW | PL_COND_FLAG_SPINDLE_CCW)), restore_spindle_speed);
+                  delay_sec(SAFETY_DOOR_SPINDLE_DELAY, DELAY_MODE_SYS_SUSPEND);
+                }
+              }
+            }
+            if (gc_state.modal.coolant != COOLANT_DISABLE) {
+              // Block if safety door re-opened during prior restore actions.
+              if (bit_isfalse(sys.suspend,SUSPEND_RESTART_RETRACT)) {
+                // NOTE: Laser mode will honor this delay. An exhaust system is often controlled by this pin.
+                coolant_set_state((restore_condition & (PL_COND_FLAG_COOLANT_FLOOD | PL_COND_FLAG_COOLANT_MIST)));
+                delay_sec(SAFETY_DOOR_COOLANT_DELAY, DELAY_MODE_SYS_SUSPEND);
+              }
+            }
+
+            #ifdef PARKING_ENABLE
+              // Execute slow plunge motion from pull-out position to resume position.
+              #ifdef ENABLE_PARKING_OVERRIDE_CONTROL
+              if (((settings.flags & (BITFLAG_HOMING_ENABLE|BITFLAG_LASER_MODE)) == BITFLAG_HOMING_ENABLE) &&
+                   (sys.override_ctrl == OVERRIDE_PARKING_MOTION)) {
+              #else
+              if ((settings.flags & (BITFLAG_HOMING_ENABLE|BITFLAG_LASER_MODE)) == BITFLAG_HOMING_ENABLE) {
+              #endif
+                // Block if safety door re-opened during prior restore actions.
+                if (bit_isfalse(sys.suspend,SUSPEND_RESTART_RETRACT)) {
+                  // Regardless if the retract parking motion was a valid/safe motion or not, the
+                  // restore parking motion should logically be valid, either by returning to the
+                  // original position through valid machine space or by not moving at all.
+                  pl_data->feed_rate = PARKING_PULLOUT_RATE;
+									pl_data->condition |= (restore_condition & PL_COND_ACCESSORY_MASK); // Restore accessory state
+									pl_data->spindle_speed = restore_spindle_speed;
+                  mc_parking_motion(restore_target, pl_data);
+                }
+              }
+            #endif
+
+            if (bit_isfalse(sys.suspend,SUSPEND_RESTART_RETRACT)) {
+              sys.suspend |= SUSPEND_RESTORE_COMPLETE;
+              system_set_exec_state_flag(EXEC_CYCLE_START); // Set to resume program.
+            }
+          }
+
+        }
+
+
+      } else {
+
+        // Feed hold manager. Controls spindle stop override states.
+        // NOTE: Hold ensured as completed by condition check at the beginning of suspend routine.
+        if (sys.spindle_stop_ovr) {
+          // Handles beginning of spindle stop
+          if (sys.spindle_stop_ovr & SPINDLE_STOP_OVR_INITIATE) {
+            if (gc_state.modal.spindle != SPINDLE_DISABLE) {
+              spindle_set_state(SPINDLE_DISABLE,0.0); // De-energize
+              sys.spindle_stop_ovr = SPINDLE_STOP_OVR_ENABLED; // Set stop override state to enabled, if de-energized.
+            } else {
+              sys.spindle_stop_ovr = SPINDLE_STOP_OVR_DISABLED; // Clear stop override state
+            }
+          // Handles restoring of spindle state
+          } else if (sys.spindle_stop_ovr & (SPINDLE_STOP_OVR_RESTORE | SPINDLE_STOP_OVR_RESTORE_CYCLE)) {
+            if (gc_state.modal.spindle != SPINDLE_DISABLE) {
+              report_feedback_message(MESSAGE_SPINDLE_RESTORE);
+              if (bit_istrue(settings.flags,BITFLAG_LASER_MODE)) {
+                // When in laser mode, ignore spindle spin-up delay. Set to turn on laser when cycle starts.
+                bit_true(sys.step_control, STEP_CONTROL_UPDATE_SPINDLE_PWM);
+              } else {
+                spindle_set_state((restore_condition & (PL_COND_FLAG_SPINDLE_CW | PL_COND_FLAG_SPINDLE_CCW)), restore_spindle_speed);
+              }
+            }
+            if (sys.spindle_stop_ovr & SPINDLE_STOP_OVR_RESTORE_CYCLE) {
+              system_set_exec_state_flag(EXEC_CYCLE_START);  // Set to resume program.
+            }
+            sys.spindle_stop_ovr = SPINDLE_STOP_OVR_DISABLED; // Clear stop override state
+          }
+        } else {
+          // Handles spindle state during hold. NOTE: Spindle speed overrides may be altered during hold state.
+          // NOTE: STEP_CONTROL_UPDATE_SPINDLE_PWM is automatically reset upon resume in step generator.
+          if (bit_istrue(sys.step_control, STEP_CONTROL_UPDATE_SPINDLE_PWM)) {
+            spindle_set_state((restore_condition & (PL_COND_FLAG_SPINDLE_CW | PL_COND_FLAG_SPINDLE_CCW)), restore_spindle_speed);
+            bit_false(sys.step_control, STEP_CONTROL_UPDATE_SPINDLE_PWM);
+          }
+        }
+
+      }
+    }
+
+    protocol_exec_rt_system();
+
+  }
+}

--- a/serial.c
+++ b/serial.c
@@ -1,0 +1,223 @@
+/*
+  serial.c - Low level functions for sending and recieving bytes via the serial port
+  Part of Grbl
+
+  Copyright (c) 2011-2016 Sungeun K. Jeon for Gnea Research LLC
+  Copyright (c) 2009-2011 Simen Svale Skogsrud
+
+  Grbl is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Grbl is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "grbl.h"
+
+#define RX_RING_BUFFER (RX_BUFFER_SIZE+1)
+#define TX_RING_BUFFER (TX_BUFFER_SIZE+1)
+
+uint8_t serial_rx_buffer[RX_RING_BUFFER];
+uint8_t serial_rx_buffer_head = 0;
+volatile uint8_t serial_rx_buffer_tail = 0;
+
+uint8_t serial_tx_buffer[TX_RING_BUFFER];
+uint8_t serial_tx_buffer_head = 0;
+volatile uint8_t serial_tx_buffer_tail = 0;
+
+
+// Returns the number of bytes available in the RX serial buffer.
+uint8_t serial_get_rx_buffer_available()
+{
+  uint8_t rtail = serial_rx_buffer_tail; // Copy to limit multiple calls to volatile
+  if (serial_rx_buffer_head >= rtail) { return(RX_BUFFER_SIZE - (serial_rx_buffer_head-rtail)); }
+  return((rtail-serial_rx_buffer_head-1));
+}
+
+
+// Returns the number of bytes used in the RX serial buffer.
+// NOTE: Deprecated. Not used unless classic status reports are enabled in config.h.
+uint8_t serial_get_rx_buffer_count()
+{
+  uint8_t rtail = serial_rx_buffer_tail; // Copy to limit multiple calls to volatile
+  if (serial_rx_buffer_head >= rtail) { return(serial_rx_buffer_head-rtail); }
+  return (RX_BUFFER_SIZE - (rtail-serial_rx_buffer_head));
+}
+
+
+// Returns the number of bytes used in the TX serial buffer.
+// NOTE: Not used except for debugging and ensuring no TX bottlenecks.
+uint8_t serial_get_tx_buffer_count()
+{
+  uint8_t ttail = serial_tx_buffer_tail; // Copy to limit multiple calls to volatile
+  if (serial_tx_buffer_head >= ttail) { return(serial_tx_buffer_head-ttail); }
+  return (TX_RING_BUFFER - (ttail-serial_tx_buffer_head));
+}
+
+
+void serial_init()
+{
+  // Set baud rate
+  #if BAUD_RATE < 57600
+    uint16_t UBRR0_value = ((F_CPU / (8L * BAUD_RATE)) - 1)/2 ;
+    UCSR0A &= ~(1 << U2X0); // baud doubler off  - Only needed on Uno XXX
+  #else
+    uint16_t UBRR0_value = ((F_CPU / (4L * BAUD_RATE)) - 1)/2;
+    UCSR0A |= (1 << U2X0);  // baud doubler on for high baud rates, i.e. 115200
+  #endif
+  UBRR0H = UBRR0_value >> 8;
+  UBRR0L = UBRR0_value;
+
+  // enable rx, tx, and interrupt on complete reception of a byte
+  UCSR0B |= (1<<RXEN0 | 1<<TXEN0 | 1<<RXCIE0);
+
+  // defaults to 8-bit, no parity, 1 stop bit
+}
+
+
+// Writes one byte to the TX serial buffer. Called by main program.
+void serial_write(uint8_t data) {
+  // Calculate next head
+  uint8_t next_head = serial_tx_buffer_head + 1;
+  if (next_head == TX_RING_BUFFER) { next_head = 0; }
+
+  // Wait until there is space in the buffer
+  while (next_head == serial_tx_buffer_tail) {
+    // TODO: Restructure st_prep_buffer() calls to be executed here during a long print.
+    if (sys_rt_exec_state & EXEC_RESET) { return; } // Only check for abort to avoid an endless loop.
+  }
+
+  // Store data and advance head
+  serial_tx_buffer[serial_tx_buffer_head] = data;
+  serial_tx_buffer_head = next_head;
+
+  // Enable Data Register Empty Interrupt to make sure tx-streaming is running
+  UCSR0B |=  (1 << UDRIE0);
+}
+
+
+// Data Register Empty Interrupt handler
+ISR(SERIAL_UDRE)
+{
+  uint8_t tail = serial_tx_buffer_tail; // Temporary serial_tx_buffer_tail (to optimize for volatile)
+
+  // Send a byte from the buffer
+  UDR0 = serial_tx_buffer[tail];
+
+  // Update tail position
+  tail++;
+  if (tail == TX_RING_BUFFER) { tail = 0; }
+
+  serial_tx_buffer_tail = tail;
+
+  // Turn off Data Register Empty Interrupt to stop tx-streaming if this concludes the transfer
+  if (tail == serial_tx_buffer_head) { UCSR0B &= ~(1 << UDRIE0); }
+}
+
+
+// Fetches the first byte in the serial read buffer. Called by main program.
+uint8_t serial_read()
+{
+  uint8_t tail = serial_rx_buffer_tail; // Temporary serial_rx_buffer_tail (to optimize for volatile)
+  if (serial_rx_buffer_head == tail) {
+    return SERIAL_NO_DATA;
+  } else {
+    uint8_t data = serial_rx_buffer[tail];
+
+    tail++;
+    if (tail == RX_RING_BUFFER) { tail = 0; }
+    serial_rx_buffer_tail = tail;
+
+    return data;
+  }
+}
+
+#ifdef SERIAL_CANCEL
+//
+// Flushes and adds a SERIAL_CANCEL (CAN) character to the serial input buffer.
+// When read by protocol_main_loop it will flush the current input buffer and
+// cancel any active jog motion.
+//
+void serial_cancel_read_buffers ()
+{
+	uint8_t next_head = serial_rx_buffer_head;
+	serial_rx_buffer_tail = next_head;
+	if (++next_head == RX_RING_BUFFER) { next_head = 0; }
+	serial_rx_buffer[serial_rx_buffer_head] = SERIAL_CANCEL;
+	serial_rx_buffer_head = next_head;
+}
+#endif
+
+ISR(SERIAL_RX)
+{
+  uint8_t data = UDR0;
+  uint8_t next_head;
+
+  // Pick off realtime command characters directly from the serial stream. These characters are
+  // not passed into the main buffer, but these set system state flag bits for realtime execution.
+  switch (data) {
+    case CMD_RESET:         mc_reset(); break; // Call motion control reset routine.
+    case CMD_STATUS_REPORT: system_set_exec_state_flag(EXEC_STATUS_REPORT); break; // Set as true
+    case CMD_CYCLE_START:   system_set_exec_state_flag(EXEC_CYCLE_START); break; // Set as true
+    case CMD_FEED_HOLD:     system_set_exec_state_flag(EXEC_FEED_HOLD); break; // Set as true
+    default :
+      if (data > 0x7F) { // Real-time control characters are extended ACSII only.
+        switch(data) {
+          case CMD_SAFETY_DOOR:   system_set_exec_state_flag(EXEC_SAFETY_DOOR); break; // Set as true
+          case CMD_JOG_CANCEL:
+			#ifdef SERIAL_CANCEL
+				serial_cancel_read_buffers();
+			#else
+				if (sys.state & STATE_JOG) { // Block all other states from invoking motion cancel.
+					system_set_exec_state_flag(EXEC_MOTION_CANCEL); 
+				}
+			#endif
+            break; 
+          #ifdef DEBUG
+            case CMD_DEBUG_REPORT: {uint8_t sreg = SREG; cli(); bit_true(sys_rt_exec_debug,EXEC_DEBUG_REPORT); SREG = sreg;} break;
+          #endif
+          case CMD_FEED_OVR_RESET: system_set_exec_motion_override_flag(EXEC_FEED_OVR_RESET); break;
+          case CMD_FEED_OVR_COARSE_PLUS: system_set_exec_motion_override_flag(EXEC_FEED_OVR_COARSE_PLUS); break;
+          case CMD_FEED_OVR_COARSE_MINUS: system_set_exec_motion_override_flag(EXEC_FEED_OVR_COARSE_MINUS); break;
+          case CMD_FEED_OVR_FINE_PLUS: system_set_exec_motion_override_flag(EXEC_FEED_OVR_FINE_PLUS); break;
+          case CMD_FEED_OVR_FINE_MINUS: system_set_exec_motion_override_flag(EXEC_FEED_OVR_FINE_MINUS); break;
+          case CMD_RAPID_OVR_RESET: system_set_exec_motion_override_flag(EXEC_RAPID_OVR_RESET); break;
+          case CMD_RAPID_OVR_MEDIUM: system_set_exec_motion_override_flag(EXEC_RAPID_OVR_MEDIUM); break;
+          case CMD_RAPID_OVR_LOW: system_set_exec_motion_override_flag(EXEC_RAPID_OVR_LOW); break;
+          case CMD_SPINDLE_OVR_RESET: system_set_exec_accessory_override_flag(EXEC_SPINDLE_OVR_RESET); break;
+          case CMD_SPINDLE_OVR_COARSE_PLUS: system_set_exec_accessory_override_flag(EXEC_SPINDLE_OVR_COARSE_PLUS); break;
+          case CMD_SPINDLE_OVR_COARSE_MINUS: system_set_exec_accessory_override_flag(EXEC_SPINDLE_OVR_COARSE_MINUS); break;
+          case CMD_SPINDLE_OVR_FINE_PLUS: system_set_exec_accessory_override_flag(EXEC_SPINDLE_OVR_FINE_PLUS); break;
+          case CMD_SPINDLE_OVR_FINE_MINUS: system_set_exec_accessory_override_flag(EXEC_SPINDLE_OVR_FINE_MINUS); break;
+          case CMD_SPINDLE_OVR_STOP: system_set_exec_accessory_override_flag(EXEC_SPINDLE_OVR_STOP); break;
+          case CMD_COOLANT_FLOOD_OVR_TOGGLE: system_set_exec_accessory_override_flag(EXEC_COOLANT_FLOOD_OVR_TOGGLE); break;
+          #ifdef ENABLE_M7
+            case CMD_COOLANT_MIST_OVR_TOGGLE: system_set_exec_accessory_override_flag(EXEC_COOLANT_MIST_OVR_TOGGLE); break;
+          #endif
+        }
+        // Throw away any unfound extended-ASCII character by not passing it to the serial buffer.
+      } else { // Write character to buffer
+        next_head = serial_rx_buffer_head + 1;
+        if (next_head == RX_RING_BUFFER) { next_head = 0; }
+
+        // Write data to buffer unless it is full.
+        if (next_head != serial_rx_buffer_tail) {
+          serial_rx_buffer[serial_rx_buffer_head] = data;
+          serial_rx_buffer_head = next_head;
+        }
+      }
+  }
+}
+
+
+void serial_reset_read_buffer()
+{
+  serial_rx_buffer_tail = serial_rx_buffer_head;
+}

--- a/serial.h
+++ b/serial.h
@@ -1,0 +1,64 @@
+/*
+  serial.c - Low level functions for sending and recieving bytes via the serial port
+  Part of Grbl
+
+  Copyright (c) 2011-2016 Sungeun K. Jeon for Gnea Research LLC
+  Copyright (c) 2009-2011 Simen Svale Skogsrud
+
+  Grbl is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Grbl is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef serial_h
+#define serial_h
+
+// Comment out to revert to default jog cancel handling
+#define SERIAL_CANCEL 0x18
+
+#ifndef RX_BUFFER_SIZE
+  #define RX_BUFFER_SIZE 128
+#endif
+#ifndef TX_BUFFER_SIZE
+  #ifdef USE_LINE_NUMBERS
+    #define TX_BUFFER_SIZE 112
+  #else
+    #define TX_BUFFER_SIZE 104
+  #endif
+#endif
+
+#define SERIAL_NO_DATA 0xff
+
+
+void serial_init();
+
+// Writes one byte to the TX serial buffer. Called by main program.
+void serial_write(uint8_t data);
+
+// Fetches the first byte in the serial read buffer. Called by main program.
+uint8_t serial_read();
+
+// Reset and empty data in read buffer. Used by e-stop and reset.
+void serial_reset_read_buffer();
+
+// Returns the number of bytes available in the RX serial buffer.
+uint8_t serial_get_rx_buffer_available();
+
+// Returns the number of bytes used in the RX serial buffer.
+// NOTE: Deprecated. Not used unless classic status reports are enabled in config.h.
+uint8_t serial_get_rx_buffer_count();
+
+// Returns the number of bytes used in the TX serial buffer.
+// NOTE: Not used except for debugging and ensuring no TX bottlenecks.
+uint8_t serial_get_tx_buffer_count();
+
+#endif


### PR DESCRIPTION
added Jog cancel part of GRBL-mega patch by  [ @terjeio](https://github.com/terjeio)
#https://github.com/terjeio/grbl-Mega/commit/ed8d64433ae2b027d90911e26557f9a56c07b06e?short_path=b335630#
[MEge patch](https://github.com/terjeio/grbl-Mega)
Jogging cancel command not ignored any more.
The limitation of this patch - motion will always accelerates to the given feed rate, and than decelerates to stop, even if Jog Cancel command arrived at very beginning of motion.
